### PR TITLE
Fix undefined property of imgBucket from the `config.nro`

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -48,7 +48,7 @@ function installPluginsDependencies ({ pluginsDir }) {
 
 function createHtaccess (config) {
   const htaccessTemplate = require('../.htaccess.tpl.js')
-  const content = htaccessTemplate(config.nro.imgBucket || null)
+  const content = htaccessTemplate(config.nro?.imgBucket || null)
   writeFileSync(`${config.appDir}/.htaccess`, content)
   run(`docker compose -f $(wp-env install-path)/docker-compose.yml cp ${config.appDir}/.htaccess wordpress:/var/www/html/.htaccess`)
 }


### PR DESCRIPTION
# Description
When I install the project by running `npm run env:install` I'm getting the below error 👇 

```sh
TypeError: Cannot read properties of null (reading 'imgBucket')
    at createHtaccess (/Users/dantovbein/Documents/Clients/Greenpeace/International/Projects/planet4-develop/scripts/lib/utils.js:51:47)
    at Object.<anonymous> (/Users/dantovbein/Documents/Clients/Greenpeace/International/Projects/planet4-develop/scripts/install.js:29:1)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47
```

# About the solution
I added `?` to make sure that the installation won't file where that `property` does not exist.