### PR TITLE
Update to wp-env 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
     machine:
       image: ubuntu-2204:2023.02.1
     environment:
-      - WP_ENV_VERSION: "5.16.0"
+      - WP_ENV_VERSION: "8.0.0"
     parameters:
       notify:
         type: boolean
@@ -99,8 +99,8 @@ jobs:
             mkdir -p /home/circleci/artifacts/playwright/themes /home/circleci/artifacts/playwright/plugins
             cp -r planet4/themes/planet4-master-theme/e2e-* /home/circleci/artifacts/playwright/themes || true
             cp planet4/themes/planet4-master-theme/results.xml /home/circleci/artifacts/playwright/themes || true
-            cp -r planet4/plugins/planet4-plugins-gutenberg-blocks/e2e-* /home/circleci/artifacts/playwright/plugins || true
-            cp planet4/plugins/planet4-plugins-gutenberg-blocks/results.xml /home/circleci/artifacts/playwright/plugins || true
+            cp -r planet4/plugins/planet4-plugin-gutenberg-blocks/e2e-* /home/circleci/artifacts/playwright/plugins || true
+            cp planet4/plugins/planet4-plugin-gutenberg-blocks/results.xml /home/circleci/artifacts/playwright/plugins || true
       - store_test_results:
           path: /home/circleci/artifacts
       - store_artifacts:
@@ -119,7 +119,7 @@ jobs:
       image: ubuntu-2204:2023.02.1
     environment:
       - GOOGLE_PROJECT_ID: planet-4-151612
-      - WP_ENV_VERSION: "latest"
+      - WP_ENV_VERSION: "8.0.0"
     parameters:
       notify:
         type: boolean

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ cache/*
 content/*
 planet4/*
 node_modules/*
-.p4-env.json
+.p4-env.*.json
 .wp-env.*.json
 junit.xml

--- a/.p4-env.json
+++ b/.p4-env.json
@@ -1,0 +1,16 @@
+{
+  "planet4": {
+    "content": {
+      "db": "v0.2.18",
+      "images": "1-25"
+    },
+    "repos": {
+      "planet4-base": "main",
+      "planet4-master-theme": "main",
+      "planet4-plugin-gutenberg-blocks": "main"
+    },
+    "composer": {
+      "processTimeout": "600"
+    }
+  }
+}

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,10 +2,7 @@
   "phpVersion": "7.4",
   "core": "WordPress/WordPress#6.2",
   "mappings": {
-    "wp-content/themes": "./planet4/themes",
-    "wp-content/plugins": "./planet4/plugins",
-    "wp-content/uploads": "./planet4/uploads",
-    "wp-content/languages": "./planet4/languages"
+    "wp-content": "./planet4"
   },
   "config": {
     "WP_SITEURL": "http://www.planet4.test/",
@@ -14,20 +11,6 @@
   "env": {
     "development": {
       "port": 80
-    }
-  },
-  "planet4": {
-    "content": {
-      "db": "v0.2.23",
-      "images": "1-25"
-    },
-    "repos": {
-      "planet4-base": "main",
-      "planet4-master-theme": "main",
-      "planet4-plugin-gutenberg-blocks": "main"
-    },
-    "composer": {
-      "processTimeout": "600"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -94,25 +94,9 @@ npm run
   - you can add or create any theme in this folder, it will be available in your local instance
 - plugins are installed in `planet4/plugins`
   - if a plugin you want to work on is not writable, either use `npm run env:fix-permissions`, or remove it and clone your own repo to replace it
-  - you can add or create any theme in this folder, it will be available in your local instance
+  - you can add or create any plugin in this folder, it will be available in your local instance
 
 ## Resources
 
 - https://github.com/WordPress/gutenberg/tree/trunk/packages/env
 - https://github.com/WordPress/developer-blog-content/issues/89
-
-## To do
-
-### Perfs
-- Add Redis server to check if instance is faster that way
-
-### Permissions
-- check why everything is root (missing user with UID used by wp-env ?)
-  - https://github.com/WordPress/gutenberg/issues/28201 maybe
-
-### Composer
-- execute @site:custom scripts
-  - figure out replacement of `wp` commands 
-
-### WPML
-- String Translation issues writing in languages folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "planet4-develop",
-  "version": "v0.4",
+  "version": "v0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "planet4-develop",
-      "version": "v0.4",
+      "version": "v0.5",
       "dependencies": {
         "js-yaml": "4.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planet4-develop",
-  "version": "v0.4",
+  "version": "v0.5",
   "description": "Planet 4 development environment",
   "author": "Planet 4",
   "scripts": {

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -6,7 +6,7 @@ const config = getConfig()
 
 run('wp-env stop')
 run('wp-env clean')
-if (config.appDir.length > 0 && !config.appDir.includes('..') && isDir(config.appDir)) {
-  console.log(`Deleting all files in <${config.appDir}> ...`)
-  run(`sudo rm -rf ${config.appDir}`)
+if (config.paths.local.app.length > 0 && !config.paths.local.app.includes('..') && isDir(config.paths.local.app)) {
+  console.log(`Deleting all files in <${config.paths.local.app}> ...`)
+  run(`rm -rf ./${config.paths.local.app}`)
 }

--- a/scripts/db-import.js
+++ b/scripts/db-import.js
@@ -1,5 +1,5 @@
 const { existsSync } = require('fs')
-const { run } = require('./lib/run')
+const { wp } = require('./lib/run')
 const { createDatabase, importDatabase, useDatabase } = require('./lib/mysql')
 
 if (!process.argv[2] || !process.argv[3]) {
@@ -23,4 +23,4 @@ if (!dbName.match(/^[a-z0-9_]*$/)) {
 createDatabase(dbName)
 importDatabase(filepath, dbName)
 useDatabase(dbName)
-run('wp-env run cli user update admin --user_pass=admin --role=administrator')
+wp('user update admin --user_pass=admin --role=administrator')

--- a/scripts/db-use.js
+++ b/scripts/db-use.js
@@ -1,4 +1,4 @@
-const { run } = require('./lib/run')
+const { useDatabase } = require('./lib/mysql')
 
 if (!process.argv[2]) {
   console.log('Please use npm run db:use <dataase name>')
@@ -8,8 +8,8 @@ if (!process.argv[2]) {
 const dbName = process.argv[2]
 
 if (!dbName.match(/^[a-z0-9_]*$/)) {
-  console.log(`DB name <${dbName}> is invalid. Please use ^[a-z_]*$`)
+  console.log(`DB name <${dbName}> is invalid. Please use ^[a-z0-9_]*$`)
   process.exit(1)
 }
 
-run(`wp-env run cli config set DB_NAME ${dbName}`)
+useDatabase(dbName)

--- a/scripts/e2e.js
+++ b/scripts/e2e.js
@@ -1,6 +1,6 @@
 const { run } = require('./lib/run')
 const { getConfig } = require('./lib/config')
-const { nodeCheck } = require('./lib/node-check')
+const { nodeCheck } = require('./lib/env-check')
 const { parseArgs } = require('./lib/utils')
 
 /**
@@ -21,11 +21,11 @@ console.log(process.cwd(), '\n', config)
 const args = parseArgs(process.argv, { command: 'run' })
 
 if (args.command === 'install') {
-  run(`npx playwright install ${args.options.join(' ')}`, { cwd: `${config.themesDir}/planet4-master-theme` })
-  run(`npx playwright install ${args.options.join(' ')}`, { cwd: `${config.pluginsDir}/planet4-plugin-gutenberg-blocks` })
+  run(`npx playwright install ${args.options.join(' ')}`, { cwd: `${config.paths.local.themes}/planet4-master-theme` })
+  run(`npx playwright install ${args.options.join(' ')}`, { cwd: `${config.paths.local.plugins}/planet4-plugin-gutenberg-blocks` })
 }
 
 if (args.command === 'run') {
-  run(`npx playwright test ${args.options.join(' ')} --pass-with-no-tests`, { cwd: `${config.themesDir}/planet4-master-theme` })
-  run(`npx playwright test ${args.options.join(' ')} --pass-with-no-tests`, { cwd: `${config.pluginsDir}/planet4-plugin-gutenberg-blocks` })
+  run(`npx playwright test ${args.options.join(' ')} --pass-with-no-tests`, { cwd: `${config.paths.local.themes}/planet4-master-theme` })
+  run(`npx playwright test ${args.options.join(' ')} --pass-with-no-tests`, { cwd: `${config.paths.local.plugins}/planet4-plugin-gutenberg-blocks` })
 }

--- a/scripts/elastic.js
+++ b/scripts/elastic.js
@@ -1,4 +1,4 @@
-const { run } = require('./lib/run')
+const { run, wp } = require('./lib/run')
 const { parseArgs } = require('./lib/utils')
 
 /**
@@ -9,21 +9,21 @@ const dcConfig = '-f $(wp-env install-path)/docker-compose.yml -f scripts/docker
 
 if (args.command === 'activate') {
   run(`docker compose ${dcConfig} up --force-recreate -d elasticsearch`)
-  run('wp-env run cli option update ep_host "http://elasticsearch:9200/"')
-  run('wp-env run cli plugin activate elasticpress')
-  run('wp-env run cli elasticpress index --setup --yes')
+  wp('option update ep_host "http://elasticsearch:9200/"')
+  wp('plugin activate elasticpress')
+  wp('elasticpress index --setup --yes')
 
   // clear redis cache ?
-  run('wp-env run cli timber clear_cache &>/dev/null')
-  run('wp-env run cli cache flush')
+  wp('timber clear_cache &>/dev/null')
+  wp('cache flush')
 }
 
 if (args.command === 'deactivate') {
   run(`docker compose ${dcConfig} stop elasticsearch`)
-  run('wp-env run cli plugin deactivate elasticpress')
+  wp('plugin deactivate elasticpress')
 }
 
 if (args.command === 'stop') {
   run(`docker compose ${dcConfig} stop elasticsearch`)
-  run('wp-env run cli option delete ep_host')
+  wp('option delete ep_host')
 }

--- a/scripts/fix-permissions.js
+++ b/scripts/fix-permissions.js
@@ -5,9 +5,9 @@ const all = process.argv[2] || null
 const config = getConfig()
 
 if (all) {
-  run(`sudo find ${config.appDir} -not -user $(whoami) -exec chown -f $(whoami) {} \\+`)
-  run(`sudo chmod 777 ${config.appDir}/uploads`)
+  run(`sudo find ${config.paths.local.app} -not -user $(whoami) -exec chown -f $(whoami) {} \\+`)
+  run(`sudo chmod 777 ${config.paths.local.uploads}`)
 } else {
-  run(`sudo find ${config.themesDir}/planet4-master-theme -not -user $(whoami) -exec chown -f $(whoami) {} \\+`)
-  run(`sudo find ${config.pluginsDir}/planet4-plugin-gutenberg-blocks -not -user $(whoami) -exec chown -f $(whoami) {} \\+`)
+  run(`sudo find ${config.paths.local.themes}/planet4-master-theme -not -user $(whoami) -exec chown -f $(whoami) {} \\+`)
+  run(`sudo find ${config.paths.local.plugins}/planet4-plugin-gutenberg-blocks -not -user $(whoami) -exec chown -f $(whoami) {} \\+`)
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,7 +1,7 @@
 const { existsSync, mkdirSync } = require('fs')
-const { nodeCheck } = require('./lib/node-check')
+const { nodeCheck } = require('./lib/env-check')
 const { getConfig } = require('./lib/config')
-const { run } = require('./lib/run')
+const { run, composer, wp } = require('./lib/run')
 const { download } = require('./lib/download')
 const { getBaseRepoFromGit, getMainReposFromGit, installRepos, buildAssets } = require('./lib/main-repos')
 const { generateBaseComposerRequirements } = require('./lib/composer-requirements')
@@ -51,7 +51,7 @@ generateBaseComposerRequirements(config)
  * Install themes/plugins
  */
 console.log('Installing & activating plugins ...')
-run(`wp-env run composer -d /app/${config.appDir}/ update --ignore-platform-reqs`)
+composer('update', config.paths.container.app)
 installPluginsDependencies(config)
 
 /**
@@ -62,7 +62,7 @@ download(
   `https://storage.googleapis.com/planet4-default-content/${imagesDump}`,
   `content/${imagesDump}`
 )
-run(`unzip -qo content/${imagesDump} -d ${config.uploadsDir}`)
+run(`unzip -qo content/${imagesDump} -d ${config.paths.local.uploads}`)
 
 /**
  * Database
@@ -80,7 +80,7 @@ download(
 createDatabase(dbName)
 importDatabase(`content/${dbDump}`, dbName)
 useDatabase(dbName)
-run('wp-env run cli plugin activate --all')
-run('wp-env run cli user update admin --user_pass=admin --role=administrator')
+wp('plugin activate --all')
+wp('user update admin --user_pass=admin --role=administrator')
 
 console.log(`The local instance is now available at ${config.config.WP_SITEURL}`)

--- a/scripts/lib/config.js
+++ b/scripts/lib/config.js
@@ -2,38 +2,79 @@ const { readFileSync, existsSync } = require('fs')
 
 function getConfig (override) {
   const wpEnvConfig = JSON.parse(readFileSync('./.wp-env.json'))
-  const p4EnvConfig = existsSync('./.p4-env.json')
-    ? JSON.parse(readFileSync('./.p4-env.json')) || {}
+  const wpEnvConfigOverride = existsSync('./.wp-env.override.json')
+    ? JSON.parse(readFileSync('./.wp-env.override.json'))
     : {}
+  const p4EnvConfig = JSON.parse(readFileSync('./.p4-env.json'))
+  const p4EnvConfigOverride = existsSync('./.p4-env.override.json')
+    ? JSON.parse(readFileSync('./.p4-env.override.json')) || {}
+    : {}
+
   const appDir = 'planet4'
 
+  const merged = deepMerge(wpEnvConfig, wpEnvConfigOverride, p4EnvConfig, p4EnvConfigOverride)
+
   const config = {
-    appDir,
-    baseDir: `${appDir}/planet4-base`,
-    themesDir: wpEnvConfig.mappings['wp-content/themes'],
-    pluginsDir: wpEnvConfig.mappings['wp-content/plugins'],
-    uploadsDir: wpEnvConfig.mappings['wp-content/uploads'],
-    languagesDir: wpEnvConfig.mappings['wp-content/languages'],
+    paths: {
+      local: {
+        app: `./${appDir}`,
+        common: `./${appDir}/common`,
+        themes: `./${appDir}/themes`,
+        plugins: `./${appDir}/plugins`,
+        uploads: `./${appDir}/uploads`,
+        languages: `./${appDir}/languages`
+      },
+      container: {
+        app: '/var/www/html/wp-content',
+        common: 'wp-content/common',
+        themes: 'wp-content/themes',
+        plugins: 'wp-content/plugins',
+        uploads: 'wp-content/uploads',
+        languages: 'wp-content/languages'
+      }
+    },
     verbose: process.env.VERBOSE || false,
-    ...wpEnvConfig,
+    ...merged,
     ...override,
-    nro: getNroConfig(override?.nro || p4EnvConfig?.nro || null, appDir)
+    nro: getNroConfig(override?.nro || p4EnvConfig?.nro || null)
   }
 
   return config
 }
 
-function getNroConfig (nroConfig, appDir) {
+function getNroConfig (nroConfig) {
   return nroConfig && nroConfig.name
     ? {
         repo: `planet4-${nroConfig.name}`,
-        dir: `${appDir}/planet4-${nroConfig.name}`,
+        dir: `planet4-${nroConfig.name}`,
         db: `planet4_${nroConfig.name.replace('-', '_')}`,
         dbBucket: `planet4-${nroConfig.name}-master-db-backup`,
         imgBucket: `planet4-${nroConfig.name}-stateless`,
         ...nroConfig
       }
     : null
+}
+
+function isObject (item) {
+  return (item && typeof item === 'object' && !Array.isArray(item))
+}
+
+function deepMerge (target, ...sources) {
+  if (!sources.length) return target
+  const source = sources.shift()
+
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} })
+        deepMerge(target[key], source[key])
+      } else {
+        Object.assign(target, { [key]: source[key] })
+      }
+    }
+  }
+
+  return deepMerge(target, ...sources)
 }
 
 module.exports = {

--- a/scripts/lib/env-check.js
+++ b/scripts/lib/env-check.js
@@ -1,4 +1,5 @@
 const { readFileSync } = require('fs')
+const { runWithOutput } = require('./run')
 
 function nodeCheck () {
   const nodeVersionRequired = parseInt(readFileSync('.nvmrc'))
@@ -9,4 +10,12 @@ function nodeCheck () {
   }
 }
 
-module.exports = { nodeCheck }
+function wpenvCheck () {
+  const versionRequired = '8'
+  const versionRunning = runWithOutput('wp-env --version').split('.')[0]
+  if (versionRequired !== versionRunning) {
+    console.error(`\u001b[31m\u2717\u001b[0m This installation process requires wp-env version ${versionRequired}. Version <${versionRunning}> is not officially supported.`)
+  }
+}
+
+module.exports = { nodeCheck, wpenvCheck }

--- a/scripts/lib/mysql.js
+++ b/scripts/lib/mysql.js
@@ -1,4 +1,4 @@
-const { run } = require('./run')
+const { run, wp } = require('./run')
 
 function mysqlRootExec (cmd, opts) {
   const dcCommand = mysqlRootCommand(cmd)
@@ -33,7 +33,7 @@ function importDatabase (gzFilepath, dbName) {
 }
 
 function useDatabase (dbName) {
-  run(`wp-env run cli config set DB_NAME ${dbName}`)
+  wp(`config set DB_NAME ${dbName}`)
 }
 
 function databaseExists (dbName) {

--- a/scripts/lib/run.js
+++ b/scripts/lib/run.js
@@ -15,4 +15,33 @@ function run (cmd, opts) {
   return execSync(cmd, { stdio: 'inherit', ...opts })
 }
 
-module.exports = { run }
+function runWithOutput (cmd, opts) {
+  return String.fromCharCode(...run(cmd, { stdio: 'pipe', ...opts })).trim()
+}
+
+function wpenvRun (cmd, cwd, opts = {}) {
+  run(
+    cwd ? `wp-env run --env-cwd=${cwd} ${cmd}` : `wp-env run ${cmd}`,
+    opts
+  )
+}
+
+function cli (cmd) {
+  return wpenvRun(`cli ${cmd}`)
+}
+
+function composer (cmd, cwd) {
+  if (process.env.VERBOSE) {
+    console.log(cmd, cwd)
+  }
+  return wpenvRun(
+    `cli composer ${cmd}`,
+    cwd && cwd.startsWith('/') ? cwd : `/var/www/html/${cwd}`
+  )
+}
+
+function wp (cmd, opts) {
+  return wpenvRun(`cli wp ${cmd}`, null, opts)
+}
+
+module.exports = { run, runWithOutput, cli, composer, wp }

--- a/scripts/nro-disable.js
+++ b/scripts/nro-disable.js
@@ -1,4 +1,4 @@
-const { run } = require('./lib/run')
+const { wp } = require('./lib/run')
 const { useDatabase } = require('./lib/mysql')
 
 // merge composer files
@@ -7,4 +7,4 @@ const { useDatabase } = require('./lib/mysql')
 // opt: switch DB
 
 useDatabase('planet4_dev')
-run('wp-env run cli theme activate planet4-master-theme')
+wp('theme activate planet4-master-theme')

--- a/scripts/nro-enable.js
+++ b/scripts/nro-enable.js
@@ -1,5 +1,5 @@
 const { getConfig } = require('./lib/config')
-const { run } = require('./lib/run')
+const { composer, wp } = require('./lib/run')
 const { generateNROComposerRequirements } = require('./lib/composer-requirements')
 const { cloneIfNotExists } = require('./lib/utils')
 
@@ -29,12 +29,12 @@ if (theme) {
   themeName = theme.replace('greenpeace/', '')
   const themePath = `${config.themesDir}/${themeName}`
   cloneIfNotExists(themePath, `https://github.com/${theme}.git`)
-  run(`wp-env run composer -d /app/${config.appDir}/ remove --no-update ${theme}`)
+  composer(`remove --no-update ${theme}`, `/app/${config.paths.local.app}/`)
 }
 
-run(`wp-env run composer -d /app/${config.appDir}/ update --ignore-platform-reqs`)
+composer('update', `/app/${config.paths.local.app}/`)
 if (themeName) {
-  run(`wp-env run cli theme activate ${themeName}`)
+  wp(`theme activate ${themeName}`)
 }
 
 /**

--- a/scripts/nro-theme.js
+++ b/scripts/nro-theme.js
@@ -1,4 +1,4 @@
-const { nodeCheck } = require('./lib/node-check')
+const { nodeCheck } = require('./lib/env-check')
 const { getConfig } = require('./lib/config')
 const { cloneIfNotExists } = require('./lib/utils')
 const { getNroComposerRequirements } = require('./lib/composer-requirements')

--- a/scripts/requirements.js
+++ b/scripts/requirements.js
@@ -1,5 +1,5 @@
-const { run } = require('./lib/run')
-const { nodeCheck } = require('./lib/node-check')
+const { runWithOutput } = require('./lib/run')
+const { nodeCheck, wpenvCheck } = require('./lib/env-check')
 const { checkForNewRelease } = require('./lib/release-check')
 
 const greenCheck = '\u001b[32m\u2713\u001b[0m'
@@ -9,8 +9,8 @@ const redCross = '\u001b[31m\u2717\u001b[0m'
 function check (cmd, title, fail) {
   console.log(`\n${title}`)
   try {
-    const output = String.fromCharCode(...run(cmd, { stdio: 'pipe' }))
-    console.log(`${greenCheck} ${output.trim()}`)
+    const output = runWithOutput(cmd)
+    console.log(`${greenCheck} Found: ${output}`)
   } catch (error) {
     console.log(`${fail}`)
     if (process.env.VERBOSE) {
@@ -29,7 +29,10 @@ nodeCheck()
 
 check('docker --version', 'Docker version:', `${redCross} Not found. Please install Docker.`)
 check('docker compose version', 'Docker compose version:', `${redCross} Not found. Please install or activate Docker compose v2.`)
+
 check('wp-env --version', 'wp-env version:', `${redCross} Not found. Please install wp-env.`)
+wpenvCheck()
+
 const nvmPath = process.env.NVM_DIR ? `${process.env.NVM_DIR}/nvm.sh` : '~/.nvm/nvm.sh'
 check(`. ${nvmPath} && nvm --version`, 'nvm version:', `${redCross} Not found (nvm path used: ${nvmPath}). Please install NVM.`)
 check('curl --version', 'curl version:', `${redCross} Not found. Please install Curl.`)

--- a/scripts/shell.js
+++ b/scripts/shell.js
@@ -1,4 +1,4 @@
-const { run } = require('./lib/run')
+const { run, wp } = require('./lib/run')
 
 const shell = process.argv[2] || 'php'
 
@@ -8,7 +8,7 @@ if (shell === 'php') {
 
 if (shell === 'mysql') {
   const db = String.fromCharCode(
-    ...run('wp-env run cli config get DB_NAME', { stdio: 'pipe' })
+    ...wp('config get DB_NAME', { stdio: 'pipe' })
   ).trim()
 
   run(`docker compose -f $(wp-env install-path)/docker-compose.yml exec mysql mysql -uroot -ppassword -D ${db}`)

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -1,4 +1,4 @@
-const { nodeCheck } = require('./lib/node-check')
+const { nodeCheck } = require('./lib/env-check')
 const { getConfig } = require('./lib/config')
 const { run } = require('./lib/run')
 const { getMainReposFromRelease, installRepos } = require('./lib/main-repos')
@@ -23,19 +23,19 @@ if (isRepo(process.cwd())) {
 
 // base dir
 // reinstall dependencies ?
-if (isRepo(config.baseDir)) {
-  run('git pull || true', { cwd: `${config.baseDir}` })
+if (isRepo(`${config.paths.local.app}/planet4-base`)) {
+  run('git pull || true', { cwd: `${config.paths.local.app}/planet4-base` })
 }
 
 // main repos
-if (isRepo(`${config.themesDir}/planet4-master-theme`)
-  && isRepo(`${config.pluginsDir}/planet4-plugin-gutenberg-blocks`)
+if (isRepo(`${config.paths.local.themes}/planet4-master-theme`)
+  && isRepo(`${config.paths.local.plugins}/planet4-plugin-gutenberg-blocks`)
 ) {
-  run('git pull || true', { cwd: `${config.themesDir}/planet4-master-theme` })
-  run('git pull || true', { cwd: `${config.pluginsDir}/planet4-plugin-gutenberg-blocks` })
+  run('git pull || true', { cwd: `${config.paths.local.themes}/planet4-master-theme` })
+  run('git pull || true', { cwd: `${config.paths.local.plugins}/planet4-plugin-gutenberg-blocks` })
   installRepos(config)
-} else if (isDir(`${config.themesDir}/planet4-master-theme`)
-  && isDir(`${config.pluginsDir}/planet4-plugin-gutenberg-blocks`)
+} else if (isDir(`${config.paths.local.themes}/planet4-master-theme`)
+  && isDir(`${config.paths.local.plugins}/planet4-plugin-gutenberg-blocks`)
 ) {
   getMainReposFromRelease(config, true)
   installRepos(config)

--- a/test/config.js
+++ b/test/config.js
@@ -3,10 +3,10 @@ const { getConfig } = require('../scripts/lib/config')
 
 describe('Config', () => {
   it('Config override works', () => {
-    const override = { baseDir: 'foo', env: { development: { port: 99 } } }
+    const override = { app: 'foo', env: { development: { port: 99 } } }
     const config = getConfig(override)
 
-    assert.ok(config.baseDir === 'foo')
+    assert.ok(config.app === 'foo')
     assert.ok(config.env.development.port === 99)
   })
 


### PR DESCRIPTION
- Update to @wordpress/env 8.0.0
  - Fixes file permissions issues
  - Has grouped containers for cli/wp/composer
  - Disallow unknown config keys
- Change in content mapping and paths
- Change in functions to run wp, composer, cli commands
- wp-env version check
  - unexpected version is marked with a red cross
- change config .p4-env.json to .wp-env.json merge strategy
  - external config keys moved to .p4-env.json, override for both config used
- fix on CI E2E results export
- composer run-script site:custom works

## Update instructions

- Save your work (the update process will destroy everything)
- Destroy everything `npm run env:destroy`
- Update this repo
- Update wp-env package `npm -g install @wordpress/env@8.0.0`
- Reinstall :man_dancing: 