### PR TITLE
Drop gsutil for gcloud storage

### DIFF
--- a/scripts/db-import.js
+++ b/scripts/db-import.js
@@ -3,7 +3,7 @@ const { wp } = require('./lib/run')
 const { createDatabase, importDatabase, useDatabase } = require('./lib/mysql')
 
 if (!process.argv[2] || !process.argv[3]) {
-  console.log('Please use npm run db:import <gz file path> <dataase name>')
+  console.log('Please use npm run db:import <gz file path> <database name>')
   process.exit(1)
 }
 
@@ -23,4 +23,8 @@ if (!dbName.match(/^[a-z0-9_]*$/)) {
 createDatabase(dbName)
 importDatabase(filepath, dbName)
 useDatabase(dbName)
-wp('user update admin --user_pass=admin --role=administrator')
+try {
+  wp('user create admin admin@planet4.test --user_pass=admin --role=administrator')
+} catch (error) {
+  wp('user update admin --user_pass=admin --role=administrator')
+}

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -81,6 +81,10 @@ createDatabase(dbName)
 importDatabase(`content/${dbDump}`, dbName)
 useDatabase(dbName)
 wp('plugin activate --all')
-wp('user update admin --user_pass=admin --role=administrator')
+try {
+  wp('user create admin admin@planet4.test --user_pass=admin --role=administrator')
+} catch (error) {
+  wp('user update admin --user_pass=admin --role=administrator')
+}
 
 console.log(`The local instance is now available at ${config.config.WP_SITEURL}`)

--- a/scripts/lib/download.js
+++ b/scripts/lib/download.js
@@ -11,7 +11,7 @@ function download (src, dest, force = false) {
 }
 
 function downloadFromGcloud (src, dest) {
-  run(`gsutil cp ${src} ${dest}`)
+  run(`gcloud storage cp ${src} ${dest}`)
 }
 
 module.exports = {

--- a/scripts/requirements.js
+++ b/scripts/requirements.js
@@ -36,4 +36,4 @@ wpenvCheck()
 const nvmPath = process.env.NVM_DIR ? `${process.env.NVM_DIR}/nvm.sh` : '~/.nvm/nvm.sh'
 check(`. ${nvmPath} && nvm --version`, 'nvm version:', `${redCross} Not found (nvm path used: ${nvmPath}). Please install NVM.`)
 check('curl --version', 'curl version:', `${redCross} Not found. Please install Curl.`)
-check('gsutil version', 'gsutil version:', `${orangeCross} Not found. Install gsutil only if you want to import NRO database.`)
+check('gcloud version', 'gcloud version:', `${orangeCross} Not found. Install gcloud only if you want to import NRO database.`)


### PR DESCRIPTION
- Replace `gsutil` ([deprecated](https://cloud.google.com/storage/docs/gsutil#should-you-use)) with `gcloud storage`
- Fix broken nro:install when gcloud not logged in
- Fix admin user creation if `admin` does not exist

![Screenshot from 2023-08-22 14-14-11](https://github.com/greenpeace/planet4-develop/assets/617346/7ebb77c1-3cfb-4fdf-a64c-914c518a806a)

## Test

With gcloud logged in (check with `gcloud auth list`, login with `gcloud auth login`):
- new NRO install should work as usual

With gcloud logged **out** (use `gcloud auth revoke --all`)
- new NRO install should work and not crash, and installation should mention `Gcloud account not logged in, skipping NRO database import.`