### PR TITLE
Define shell user to avoid permissions issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "elastic:activate": "node ./scripts/elastic.js activate",
     "elastic:deactivate": "node ./scripts/elastic.js deactivate",
     "elastic:stop": "node ./scripts/elastic.js stop",
+    "shell": "node ./scripts/shell.js php",
     "shell:php": "node ./scripts/shell.js php",
+    "shell:php:root": "node ./scripts/shell.js php:root",
     "shell:mysql": "node ./scripts/shell.js mysql",
     "lint": "eslint",
     "test": "mocha --reporter mocha-junit-reporter --reporter-options mochaFile=junit.xml"

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -1,6 +1,7 @@
 const { existsSync, lstatSync, readdirSync, readFileSync, writeFileSync } = require('fs')
 const { run, composer } = require('./run')
 const yaml = require('js-yaml')
+const os = require('os')
 
 function isDir (path) {
   return existsSync(path) && lstatSync(path).isDirectory()
@@ -86,6 +87,19 @@ function parseArgs (args, def) {
   return parsed
 }
 
+// Cf. https://github.com/WordPress/gutenberg/blob/trunk/packages/env/lib/get-host-user.js
+function getHostUser () {
+  const hostUser = os.userInfo()
+  const uid = (hostUser.uid === -1 ? 1000 : hostUser.uid).toString()
+  const gid = (hostUser.gid === -1 ? 1000 : hostUser.gid).toString()
+  return {
+    name: hostUser.username,
+    uid,
+    gid,
+    fullUser: uid + ':' + gid
+  }
+}
+
 module.exports = {
   isDir,
   isRepo,
@@ -94,5 +108,6 @@ module.exports = {
   installPluginsDependencies,
   createHtaccess,
   readYaml,
-  parseArgs
+  parseArgs,
+  getHostUser
 }

--- a/scripts/shell.js
+++ b/scripts/shell.js
@@ -1,8 +1,13 @@
 const { run, wp } = require('./lib/run')
+const { getHostUser } = require('./lib/utils')
 
 const shell = process.argv[2] || 'php'
 
 if (shell === 'php') {
+  run(`docker compose -f $(wp-env install-path)/docker-compose.yml exec --user ${getHostUser().fullUser} wordpress bash`)
+}
+
+if (shell === 'php:root') {
   run('docker compose -f $(wp-env install-path)/docker-compose.yml exec wordpress bash')
 }
 


### PR DESCRIPTION
When running `npm run shell:php`
- use current system user
  - this avoids creating files as root (when running composer for example) that would break file permissions outside the container
- add `npm run shell:php:root` to keep root capacity

![Screenshot from 2023-08-23 11-03-50](https://github.com/greenpeace/planet4-develop/assets/617346/450051de-610c-4ae8-9fde-1983712afb0a)


## Test

- Run `npm run shell:php`
  - you should be identified as your system user inside the container 
- Run `npm run shell:php:root`
  - you should be identified as `root` inside the container 

