### PR TITLE
Fix failing e2e test job on hanging html report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
               CI:
               PW_RETRIES: 1
               PW_WORKERS: 3
+              PW_TEST_HTML_REPORT_OPEN: "never"
           command: |
               echo -e "\n# Planet4 local development environment\n127.0.0.1\twww.planet4.test" | sudo tee -a /etc/hosts;
               nvm use


### PR DESCRIPTION
HTML report opens when flaky tests are detected, which makes the CI hang and fail.

Example: https://app.circleci.com/pipelines/github/greenpeace/planet4-develop/350/workflows/e3fb0976-f8b6-45ba-af3f-83754b3a5d4d/jobs/1147

Using [`PW_TEST_HTML_REPORT_OPEN`](https://playwright.dev/docs/test-reporters#html-reporter) to fix the behavior, and also integrating it in master-theme/gutenberg-blocks.