### PR TITLE
Enable debug config and install query-monitor plugin

### DIFF
--- a/.wp-env.override.json.dist
+++ b/.wp-env.override.json.dist
@@ -1,0 +1,10 @@
+{
+  "config": {
+    "WP_APP_ENV": "local",
+    "WP_CACHE": false,
+    "WP_DEBUG": false,
+    "WP_DEBUG_LOG": true,
+    "SCRIPT_DEBUG": true,
+    "QM_ENABLE_CAPS_PANEL": true
+  }
+}

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -55,6 +55,12 @@ composer('update', config.paths.container.app);
 installPluginsDependencies(config);
 
 /**
+ * Install development requirements
+ */
+console.log('Installing development requirements ...');
+run('cp -n .wp-env.override.json.dist .wp-env.override.json');
+
+/**
  * Images
  */
 const imagesDump = `planet4-default-content-${config.planet4.content.images}-images.zip`;
@@ -75,6 +81,7 @@ importDefaultContent(config.planet4.content.db);
  */
 wp('plugin activate --all');
 wp('plugin deactivate elasticpress');
+run('npx wp-env run cli wp plugin install query-monitor');
 
 console.log(
   `The local instance is now available at ${config.config.WP_SITEURL}`


### PR DESCRIPTION
- Setting up some default configuration for better debugging during development.
- Installing the Query Monitor plugin that provides admin bar to monitor requests and queries.