### PR TITLE
feat: 🔨 better help text for checkForNewRelease()

### DIFF
--- a/scripts/requirements.js
+++ b/scripts/requirements.js
@@ -19,29 +19,36 @@ function check(cmd, title, fail) {
   }
 }
 
-checkForNewRelease();
+async function main() {
+  console.log('Shell: ');
+  console.log(process.env.SHELL);
 
-console.log('Shell: ');
-console.log(process.env.SHELL);
+  console.log('Node version: ' + process.version);
+  nodeCheck();
 
-console.log('Node version: ' + process.version);
-nodeCheck();
+  check(
+    'docker --version',
+    'Docker version:',
+    `${redCross} Not found. Please install Docker.`
+  );
+  check(
+    'docker compose version',
+    'Docker compose version:',
+    `${redCross} Not found. Please install or activate Docker compose v2.`
+  );
 
-check(
-  'docker --version',
-  'Docker version:',
-  `${redCross} Not found. Please install Docker.`
-);
-check(
-  'docker compose version',
-  'Docker compose version:',
-  `${redCross} Not found. Please install or activate Docker compose v2.`
-);
+  check('npx wp-env --version', 'wp-env version:', `${redCross} Not found. Please install wp-env.`);
+  wpenvCheck();
 
-check('npx wp-env --version', 'wp-env version:', `${redCross} Not found. Please install wp-env.`);
-wpenvCheck();
+  const nvmPath = process.env.NVM_DIR ? `${process.env.NVM_DIR}/nvm.sh` : '~/.nvm/nvm.sh';
+  check(`. ${nvmPath} && nvm --version`, 'nvm version:', `${redCross} Not found (nvm path used: ${nvmPath}). Please install NVM.`);
+  check('curl --version', 'curl version:', `${redCross} Not found. Please install Curl.`);
+  check('gcloud version', 'gcloud version:', `${orangeCross} Not found. Install gcloud only if you want to import NRO database.`);
+  console.log();
 
-const nvmPath = process.env.NVM_DIR ? `${process.env.NVM_DIR}/nvm.sh` : '~/.nvm/nvm.sh';
-check(`. ${nvmPath} && nvm --version`, 'nvm version:', `${redCross} Not found (nvm path used: ${nvmPath}). Please install NVM.`);
-check('curl --version', 'curl version:', `${redCross} Not found. Please install Curl.`);
-check('gcloud version', 'gcloud version:', `${orangeCross} Not found. Install gcloud only if you want to import NRO database.`);
+  await checkForNewRelease({
+    greenCheck, orangeCross, redCross,
+  });
+}
+
+main();


### PR DESCRIPTION
What:
in scripts/requirements.js:
1) code put inside an async function so we can await another function 2) checkForRelease() now awaited and moved to end (so its output falls
  at the end of the execution, just like presently

in scripts/release-check.js:
1) we make checkForNewRelease an async function and switch over from promise syntax (see "releaseInfo.then()..." change) 2) introduce helper to fetch from github based on a subpath 3) add new function to get the commit of the main branch in github (this seems to fix a bug where previously "target_commitish" was "main" rather than a SHA) 4) update the logging in checkForNewRelease to use colors / icons similar to how the requirements.js works (in fact we pass in checkmark icons etc).