### PR TITLE
Deactivate ElasticPress plugin by default

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -82,6 +82,7 @@ createDatabase(dbName);
 importDatabase(`content/${dbDump}`, dbName);
 useDatabase(dbName);
 wp('plugin activate --all');
+wp('plugin deactivate elasticpress');
 try {
   wp('user create admin admin@planet4.test --user_pass=admin --role=administrator');
 } catch (error) {


### PR DESCRIPTION
Since we don't run the ElasticSearch container by default, no need to activate the plugin either.

On `npm run elastic:activate` the plugin will be [activated](https://github.com/greenpeace/planet4-develop/blob/8db7b4ba36e543fd50baf48fe9bd87ad068c10f8/scripts/elastic.js#L13).

Fixes greenpeace/planet4#186