### PR TITLE
Add two commands: db:reset and db:admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "nro:theme": "node ./scripts/nro-theme.js",
     "build:assets": "node ./scripts/build-assets.js",
     "build:repos": "node ./scripts/build-repos.js",
+    "db:admin": "node ./scripts/db-admin.js",
     "db:import": "node ./scripts/db-import.js",
     "db:reset": "node ./scripts/db-reset.js",
     "db:use": "node ./scripts/db-use.js",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:assets": "node ./scripts/build-assets.js",
     "build:repos": "node ./scripts/build-repos.js",
     "db:import": "node ./scripts/db-import.js",
+    "db:reset": "node ./scripts/db-reset.js",
     "db:use": "node ./scripts/db-use.js",
     "elastic:activate": "node ./scripts/elastic.js activate",
     "elastic:deactivate": "node ./scripts/elastic.js deactivate",

--- a/scripts/db-admin.js
+++ b/scripts/db-admin.js
@@ -1,0 +1,3 @@
+const {createAdminUser} = require('./lib/admin-user');
+
+createAdminUser();

--- a/scripts/db-import.js
+++ b/scripts/db-import.js
@@ -1,6 +1,6 @@
 const {existsSync} = require('fs');
-const {wp} = require('./lib/run');
 const {createDatabase, importDatabase, useDatabase} = require('./lib/mysql');
+const {createAdminUser} = require('./lib/admin-user');
 
 if (!process.argv[2] || !process.argv[3]) {
   console.log('Please use npm run db:import <gz file path> <database name>');
@@ -23,8 +23,4 @@ if (!dbName.match(/^[a-z0-9_]*$/)) {
 createDatabase(dbName);
 importDatabase(filepath, dbName);
 useDatabase(dbName);
-try {
-  wp('user create admin admin@planet4.test --user_pass=admin --role=administrator');
-} catch (error) {
-  wp('user update admin --user_pass=admin --user_email=admin@planet4.test --role=administrator');
-}
+createAdminUser();

--- a/scripts/db-reset.js
+++ b/scripts/db-reset.js
@@ -1,0 +1,5 @@
+const {getConfig} = require('./lib/config');
+const {importDefaultContent} = require('./lib/db-defaultcontent');
+
+const config = getConfig();
+importDefaultContent(config.planet4.content.db);

--- a/scripts/lib/admin-user.js
+++ b/scripts/lib/admin-user.js
@@ -1,0 +1,13 @@
+const {wp} = require('./run');
+
+function createAdminUser() {
+  try {
+    wp('user create admin admin@planet4.test --user_pass=admin --role=administrator');
+  } catch (error) {
+    wp('user update admin --user_pass=admin --user_email=admin@planet4.test --role=administrator');
+  }
+}
+
+module.exports = {
+  createAdminUser,
+};

--- a/scripts/lib/db-defaultcontent.js
+++ b/scripts/lib/db-defaultcontent.js
@@ -1,7 +1,7 @@
 const {existsSync, mkdirSync} = require('fs');
-const {wp} = require('./run');
 const {download} = require('./download');
 const {createDatabase, importDatabase, useDatabase} = require('./mysql');
+const {createAdminUser} = require('./admin-user');
 
 function importDefaultContent(dbVersion) {
   if (!existsSync('content')) {
@@ -24,11 +24,7 @@ function importDefaultContent(dbVersion) {
   importDatabase(`content/${dbDump}`, dbName);
 
   useDatabase(dbName);
-  try {
-    wp('user create admin admin@planet4.test --user_pass=admin --role=administrator');
-  } catch (error) {
-    wp('user update admin --user_pass=admin --user_email=admin@planet4.test --role=administrator');
-  }
+  createAdminUser();
 }
 
 module.exports = {

--- a/scripts/lib/db-defaultcontent.js
+++ b/scripts/lib/db-defaultcontent.js
@@ -1,0 +1,36 @@
+const {existsSync, mkdirSync} = require('fs');
+const {wp} = require('./run');
+const {download} = require('./download');
+const {createDatabase, importDatabase, useDatabase} = require('./mysql');
+
+function importDefaultContent(dbVersion) {
+  if (!existsSync('content')) {
+    mkdirSync('content');
+  }
+  const dbName = 'planet4_dev';
+  const dbDump = `planet4-defaultcontent_wordpress-${dbVersion}.sql.gz`;
+
+  download(
+    `https://storage.googleapis.com/planet4-default-content/${dbDump}`,
+    `content/${dbDump}`
+  );
+
+  try {
+    createDatabase(dbName);
+  } catch (error) {
+    console.error('\x1b[1m\x1b[31m', 'Error:', '\x1b[0m', 'mysql container is not running!');
+    process.exit(1);
+  }
+  importDatabase(`content/${dbDump}`, dbName);
+
+  useDatabase(dbName);
+  try {
+    wp('user create admin admin@planet4.test --user_pass=admin --role=administrator');
+  } catch (error) {
+    wp('user update admin --user_pass=admin --user_email=admin@planet4.test --role=administrator');
+  }
+}
+
+module.exports = {
+  importDefaultContent,
+};

--- a/scripts/nro-install.js
+++ b/scripts/nro-install.js
@@ -7,6 +7,7 @@ const {createHtaccess, makeDirStructure, cloneIfNotExists, readYaml} = require('
 const {createDatabase, importDatabase, databaseExists, useDatabase} = require('./lib/mysql');
 const {basename} = require('path');
 const {existsSync} = require('fs');
+const {createAdminUser} = require('./lib/admin-user');
 
 /**
  * Node version control
@@ -135,11 +136,7 @@ try {
 }
 
 // Create/update admin user
-try {
-  wp('user create admin admin@planet4.test --user_pass=admin --role=administrator');
-} catch (error) {
-  wp('user update admin --user_pass=admin --user_email=admin@planet4.test --role=administrator');
-}
+createAdminUser();
 if (themeName) {
   wp(`theme activate ${themeName}`);
 }


### PR DESCRIPTION
Moved some code on `scripts/lib` since we use it a more than one place and then added those two commands:

- `npm run db:reset`:  Downloads and imports the defaultcontent database, using the version defined in the config file.
- `npm run db:admin`: Creates (or activates) the admin user, in case we want to run it manually after a db import.

### Testing.
1. Test initial `npm run env:install`. It should work same as before, getting the defaultcontent and an admin login.
2. On a running environment test the new commands.