### PR TITLE
PLANET-7565: Upgrade to Wordpress 6.6.1

### DIFF
--- a/.p4-env.json
+++ b/.p4-env.json
@@ -6,7 +6,7 @@
     },
     "repos": {
       "planet4-base": "main",
-      "planet4-master-theme": "PLANET-7565_fix_automated_tests_for_wp_6.6",
+      "planet4-master-theme": "main",
       "planet4-plugin-gutenberg-blocks": "main"
     },
     "composer": {

--- a/.p4-env.json
+++ b/.p4-env.json
@@ -6,7 +6,7 @@
     },
     "repos": {
       "planet4-base": "main",
-      "planet4-master-theme": "main",
+      "planet4-master-theme": "PLANET-7565_fix_automated_tests_for_wp_6.6",
       "planet4-plugin-gutenberg-blocks": "main"
     },
     "composer": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "phpVersion": "8.1",
-  "core": "WordPress/WordPress#6.6",
+  "core": "WordPress/WordPress#6.6.1",
   "mappings": {
     "wp-content": "./planet4"
   },

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "phpVersion": "8.1",
-  "core": "WordPress/WordPress#6.5.3",
+  "core": "WordPress/WordPress#6.6",
   "mappings": {
     "wp-content": "./planet4"
   },


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-7565

<hr>

**DESCRIPTION:**
This PR upgrades the DEV instance of WordPress to its LTS version ([6.6.1 of 23 July, 2024](https://wordpress.org/download/releases/))

<hr>

**RELATED PRs TO MERGE IN PARALLEL**
- https://github.com/greenpeace/planet4-base/pull/305
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1222
- https://github.com/greenpeace/planet4-master-theme/pull/2330
- https://github.com/greenpeace/planet4-master-theme/pull/2334
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1230
- https://github.com/greenpeace/planet4-master-theme/pull/2337
- https://github.com/greenpeace/planet4-plugin-gutenberg-blocks/pull/1226

<hr>

**TESTING:**
Locally: Run `npx wp-env run cli wp core update --version=6.6.1` or `npx wp-env run cli wp core update https://wordpress.org/wordpress-6.6.1.zip` on your terminal