### PR TITLE
Remove previously created databases on local

### DIFF
--- a/scripts/lib/db-defaultcontent.js
+++ b/scripts/lib/db-defaultcontent.js
@@ -1,4 +1,5 @@
 const {existsSync, mkdirSync} = require('fs');
+const {run} = require('./run');
 const {download} = require('./download');
 const {createDatabase, importDatabase, useDatabase} = require('./mysql');
 const {createAdminUser} = require('./admin-user');
@@ -9,6 +10,9 @@ function importDefaultContent(dbVersion) {
   }
   const dbName = 'planet4_dev';
   const dbDump = `planet4-defaultcontent_wordpress-${dbVersion}.sql.gz`;
+
+  // Make sure to remove the exising databases
+  run('rm -rf planet4-defaultcontent_wordpress-*.sql.gz');
 
   download(
     `https://storage.googleapis.com/planet4-default-content/${dbDump}`,


### PR DESCRIPTION
# Description
We need this command to make sure to prune all unnecesary databases when you try resetting those. 
If the downloaded db version is already on local then you'll get: `content/planet4-defaultcontent_wordpress-{{version}}.sql.gz already exists.`.

## Testing
Just run `db:reset` and everything will work as expected