### PR TITLE
Change wp-stateless mode to ephemeral

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -88,6 +88,7 @@ importDefaultContent(config.planet4.content.db);
  */
 wp('plugin activate --all');
 wp('plugin deactivate elasticpress');
+wp('option update sm_mode "ephemeral"');
 run('npx wp-env run cli wp plugin install query-monitor');
 
 console.log(

--- a/scripts/nro-install.js
+++ b/scripts/nro-install.js
@@ -163,6 +163,7 @@ if (ciConfig) {
 }
 
 wp('plugin deactivate elasticpress');
+wp('option update sm_mode "ephemeral"');
 
 console.log(
   `The local instance is now available at ${config.config.WP_SITEURL}`


### PR DESCRIPTION
This fixes image issues where some sizes are being used with the wrong url. This causes broken urls in certain use cases (eg. articles block).

### Testing
To see the problem:
1. Clone a new develop environment.
2. Stay on the `main` branch.
3. Spin up a new development environment with an nro site (eg. `npm run nro:install switzerland`)
4. Browse the front page, you'll see the Articles block missing thumbnail images.
5. Running `npx wp-env run cli wp option update sm_mode ephemeral` and refreshing would fix the images.

To verify the fix:
1. Clone a new develop environment.
2. Switch to this branch.
3. Spin up a new development environment with an nro site (eg. `npm run nro:install switzerland`)
4. Browse the front page. All images should be properly displayed.