### PR TITLE
Configure hosts file when installing NRO version

### DIFF
--- a/scripts/nro-install.js
+++ b/scripts/nro-install.js
@@ -8,12 +8,19 @@ const {createDatabase, importDatabase, databaseExists, useDatabase} = require('.
 const {basename} = require('path');
 const {existsSync} = require('fs');
 const {createAdminUser} = require('./lib/admin-user');
+const {configureHosts} = require('./lib/hosts');
 
 /**
  * Node version control
  */
 console.log('Node version: ' + process.version);
 nodeCheck();
+
+/**
+ * Configure hosts file
+ */
+console.log('Configure /etc/hosts file ...');
+configureHosts();
 
 /**
  * Config


### PR DESCRIPTION
Adds checking for hosts configuration in the nro:install script and adds it if missing.

Without this, the hosts file is not updated for NRO developers if they directly install their NRO version. The result is, that the website is not available locally from the domain `www.planet4.test`.