### PR TITLE
Adjsut release check script to rely on git instead of package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "planet4-develop",
-  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "planet4-develop",
-  "version": "0.17.0",
   "description": "Planet 4 development environment",
   "author": "Planet 4",
   "scripts": {


### PR DESCRIPTION
Since we don't publish to npm registry we can omit the version attribute from `package.json`.

Instead we can rely on git to determine if user is on latest release by comparing local commit hash with latest release/tag commit hash.

### Testing
- While in this branch, just run: `npm run env:requirements` and you should get the version mismatch message since you are on a different commit than the latest release
  ```
  New Planet 4 developer environment release available: v0.17.0
  You should update!
  ```
- Then you have to preserve the script to test it out while on latest release:
  ```
  cp scripts/lib/release-check.js .
  git checkout v0.17.0
  mv release-check.js scripts/lib/
  npm run env:requirements
  ```
- You shouldn't get any "new version" message.