### PR TITLE
Retire blocks plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
           name: Extract tests artifacts
           when: always
           command: |
+            mkdir -p /home/circleci/artifacts/playwright
             cp -r planet4/themes/planet4-master-theme/e2e-* /home/circleci/artifacts/playwright || true
             cp planet4/themes/planet4-master-theme/results.xml /home/circleci/artifacts/playwright || true
       - store_test_results:


### PR DESCRIPTION
- Simplify  CI test artifacts folders
- Remove plugin references from installation scripts
- Remove unused vscode workspace file

---

Ref: https://jira.greenpeace.org/browse/PLANET-7740