### PR TITLE
Disable the SSO login in the NROs' local instance

### DIFF
--- a/scripts/db-import.js
+++ b/scripts/db-import.js
@@ -1,6 +1,7 @@
 const {existsSync} = require('fs');
 const {createDatabase, importDatabase, useDatabase} = require('./lib/mysql');
 const {createAdminUser} = require('./lib/admin-user');
+const {disableSso} = require('./lib/utils');
 
 if (!process.argv[2] || !process.argv[3]) {
   console.log('Please use npm run db:import <gz file path> <database name>');
@@ -22,5 +23,6 @@ if (!dbName.match(/^[a-z0-9_]*$/)) {
 
 createDatabase(dbName);
 importDatabase(filepath, dbName);
+disableSso();
 useDatabase(dbName);
 createAdminUser();

--- a/scripts/db-reset.js
+++ b/scripts/db-reset.js
@@ -1,5 +1,7 @@
 const {getConfig} = require('./lib/config');
 const {importDefaultContent} = require('./lib/db-defaultcontent');
+const {disableSso} = require('./lib/utils');
 
 const config = getConfig();
 importDefaultContent(config.planet4.content.db);
+disableSso();

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -2,7 +2,7 @@ const {getConfig} = require('./lib/config');
 const {run, runWithOutput, composer, wp} = require('./lib/run');
 const {getBaseRepoFromGit, getMainReposFromGit, installRepos, buildAssets, setComposerConfig} = require('./lib/main-repos');
 const {generateBaseComposerRequirements, generateNROComposerRequirements} = require('./lib/composer-requirements');
-const {installPluginsDependencies, createHtaccess, makeDirStructure, cloneIfNotExists, readYaml} = require('./lib/utils');
+const {installPluginsDependencies, createHtaccess, makeDirStructure, cloneIfNotExists, readYaml, disableSso} = require('./lib/utils');
 const {createDatabase, importDatabase, databaseExists, useDatabase} = require('./lib/mysql');
 const {importDefaultContent} = require('./lib/db-defaultcontent');
 const {basename} = require('path');
@@ -157,6 +157,7 @@ if (importDB) {
           }
         }
       }
+      disableSso();
     } catch (error) {
       console.log('Error trying to import NRO database.');
       if (process.env.VERBOSE) {

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -103,6 +103,14 @@ function getHostUser () {
   };
 }
 
+function disableSso() {
+  try {
+    run('npx wp-env run cli wp option patch delete planet4_features enforce_sso');
+  } catch (e) {
+    console.error('Failed to disable SSO:', e);
+  }
+}
+
 module.exports = {
   isDir,
   isRepo,
@@ -113,4 +121,5 @@ module.exports = {
   readYaml,
   parseArgs,
   getHostUser,
+  disableSso,
 };


### PR DESCRIPTION
### Summary

This PR disables the SSO login in the NROs' local instance when the Planet 4 development environment is installed. This prevents login issues in the local instance, since the SSO login is not permitted locally.

---

Ref: https://greenpeace-gpi.slack.com/archives/C0160MX64AG/p1774516673160249 

### Testing

1. Switch to the `main`branch of the `planet4-develop` repository.
2. Install an NRO development environment locally.
3. Run the command `npx wp-env run cli wp option get planet4_features`. You should see `enforce_sso => 'on'`
4. Try to log in to the admin area. You should be redirected to the SSO login.
5. Destroy the environment.
6. Switch to this branch.
7. Install the same NRO development environment locally.
8. Run the command `npx wp-env run cli wp option get planet4_features`. You should NOT see `enforce_sso => 'on'`
9. Try to log in to the admin area. You should be redirected to the default login form.
10. Import a database using the command `npm run db:import <dump path> <db name>` (ie, `npm run db:import planet4-australiapacific-master-v0.90-20250414T054230Z.sql.gz planet4_australiapacific`)
11. Try to log in to the admin area. You should be redirected to the default login form.
12. Reset the database using the command `npm run db:reset` 
13.  Try to log in to the admin area. You should be redirected to the default login form.