### PR TITLE
Disable Google plugin redirection

### DIFF
--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -106,6 +106,7 @@ function getHostUser () {
 function disableSso() {
   try {
     run('npx wp-env run cli wp option patch delete planet4_features enforce_sso');
+    run('npx wp-env run cli wp option patch delete galogin ga_auto_login');
   } catch (e) {
     console.error('Failed to disable SSO:', e);
   }


### PR DESCRIPTION
As we enable this for all sites, we need to disable it for dev environment to able to login.

This needs to be merged along with https://github.com/greenpeace/planet4-base/pull/378