### PR TITLE
Fix SSO function to run on installation script

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -157,7 +157,6 @@ if (importDB) {
           }
         }
       }
-      disableSso();
     } catch (error) {
       console.log('Error trying to import NRO database.');
       if (process.env.VERBOSE) {
@@ -176,6 +175,9 @@ if (importDB) {
     importDefaultContent(config.planet4.content.db);
   }
 }
+
+// Disable SSO
+disableSso();
 
 // Create/update admin user
 createAdminUser();

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -106,9 +106,14 @@ function getHostUser () {
 function disableSso() {
   try {
     run('npx wp-env run cli wp option patch delete planet4_features enforce_sso');
-    run('npx wp-env run cli wp option patch delete galogin ga_auto_login');
   } catch (e) {
     console.error('Failed to disable SSO:', e);
+  }
+
+  try {
+    run('npx wp-env run cli wp option patch delete galogin ga_auto_login');
+  } catch (e) {
+    console.error('Failed to disable Google redirect:', e);
   }
 }
 


### PR DESCRIPTION
## Summary

- It was only running on NRO installations
- Split the commands to ensure they both run

### Testing

On a fresh install, when accessing `/wp-admin` you should be prompted to login with credentials.